### PR TITLE
Bump Alpine Linux docker image to 3.21.0

### DIFF
--- a/resources/lab/README.md
+++ b/resources/lab/README.md
@@ -70,7 +70,7 @@ The following tasks should be executed on the student's physical machine:
 
 ### Meritorious ("VG")
 The following tasks should be executed in the student's Ubuntu environment (physical or virtual):
-- Create Dockerfile based on Alpine Linux version 3.19 for lab application and its dependencies:
+- Create Dockerfile based on Alpine Linux version 3.21.0 for lab application and its dependencies:
   - ["FIGlet" executable/package](http://www.figlet.org/)
   - Python 3 libraries/modules and their dependencies:
     - Flask version 3.0.0


### PR DESCRIPTION
The docker image version 3.19 ships ships with openssl 3.1.7-r0 which is vulnerable to CVE-2024-9143. Alpine Linux docker image vesion 3.21.0 ships instead with a patched openssl version 3.3.2-r4